### PR TITLE
Credit the correct authors for the IF1 disassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,7 @@ Also, from your parts bin:
 for his Pico to Pico PIO [communications code](https://github.com/blackjetrock/picoputer),
 and his patiently answering so many of my questions.
 
-[Tomaz Solc](https://www.tablix.org/~avian/blog/articles/about/) for his superb
-[IF1 ROM disassembly](https://www.tablix.org/~avian/spectrum/rom/if1_2.htm), which I
-suspect I now understand better than he does.
+Geoff Wearmouth and others for their superb [IF1 ROM disassembly](https://www.tablix.org/~avian/spectrum/rom/if1_2.htm), which I suspect I now understand better than them.
 
 Gergely Szasz, Philip Kendall and Stuart Brady from the
 [FUSE Emulator Project](https://sourceforge.net/projects/fuse-emulator/).


### PR DESCRIPTION
While I appreciate the acknowledgement, the only credit I can take for the IF1 disassembly is for hosting it on my server. I had no part in creating it.

The original page where this disassembly was hosted listed Geoff Wearmouth as the maintainer. There is also a comment at the end of the linked file that credits others with specific parts of the documentation. It is them who should get the credit for their excellent work.

I briefly explain how I ended up hosting the files here:

https://www.tablix.org/~avian/spectrum/rom/